### PR TITLE
Allow this library to easy integrate in platformIO

### DIFF
--- a/Examples/linux/vdm_dump.cpp
+++ b/Examples/linux/vdm_dump.cpp
@@ -28,6 +28,8 @@
 
 */
 
+#ifndef ESP32
+
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>
@@ -250,3 +252,5 @@ int main(int argc, char* argv[])
     }
     return 0;
 }
+
+#endif

--- a/library.json
+++ b/library.json
@@ -1,0 +1,22 @@
+{
+  "name": "AIS",
+  "description": "AIS library for arduino to decode the content of the AIVDM messages",
+  "keywords": "ais",
+  "version": "0.1.0",
+  "exclude": [
+    "Examples/linux/*"
+  ],
+  "build_src_filter": [
+    "+<AIS.*>",
+    "-<Examples/**/*>"
+  ],
+  "examples": [
+    {
+      "name": "AISDecode",
+      "base": "Examples/AISDecode",
+      "files": [
+        "AISDecode.ino"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Thanks for your library.
I used it in small project:   https://github.com/marcelrv/MAIANA-WiFi/

Unfortunately needed to copy the files to the project instead of directly referencing the github repository.
PlatformIO somehow tries to compile all the files, inclusing the linux example one and obvious runs into all sort of issues.

With proposed small changes it excludes the linux file from the compiling (at least on esp32) so we can easier integrate it and directly reference your github.